### PR TITLE
remove application label to fix manifest merger errors

### DIFF
--- a/elasticdragdismisslayout/src/main/AndroidManifest.xml
+++ b/elasticdragdismisslayout/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.commit451.elasticdragdismisslayout">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>

--- a/elasticdragdismisslayout/src/main/res/values/strings.xml
+++ b/elasticdragdismisslayout/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">elasticdragdismisslayout</string>
-</resources>


### PR DESCRIPTION
If you add the library and your application label is not "app_name" then gradle fails to build. This just removes the unused app_name string.