### PR TITLE
AndroidX migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ android:
 
 before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - sdkmanager tools
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - yes | sdkmanager tools
   - chmod +x gradlew
 
 script: "./gradlew build"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.commit451.elasticdragdismisslayout.sample"
@@ -19,6 +19,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -27,8 +31,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
 
-    implementation 'com.jakewharton:butterknife:8.8.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+    implementation 'com.jakewharton:butterknife:10.0.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.0.0'
 
     implementation 'com.github.bumptech.glide:glide:4.3.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,10 +22,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support:design:27.0.2'
-    implementation 'com.android.support:recyclerview-v7:27.0.2'
-    implementation 'com.android.support:cardview-v7:27.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
 
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/CheeseAdapter.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/CheeseAdapter.java
@@ -1,9 +1,10 @@
 package com.commit451.elasticdragdismisslayout.sample;
 
 import android.content.Context;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/CheeseViewHolder.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/CheeseViewHolder.java
@@ -1,11 +1,12 @@
 package com.commit451.elasticdragdismisslayout.sample;
 
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * The view holder related to each Cheese item

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/ColorUtils.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/ColorUtils.java
@@ -16,16 +16,17 @@
 
 package com.commit451.elasticdragdismisslayout.sample;
 
-import android.support.annotation.ColorInt;
-import android.support.annotation.FloatRange;
-import android.support.annotation.IntRange;
+import androidx.annotation.ColorInt;
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
 
 /**
  * Utility methods for working with colors.
  */
 public class ColorUtils {
 
-    private ColorUtils() { }
+    private ColorUtils() {
+    }
 
     /**
      * Set the alpha component of {@code color} to be {@code alpha}.

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/DetailActivity.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/DetailActivity.java
@@ -4,10 +4,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.transition.TransitionInflater;
 import android.view.View;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import com.commit451.elasticdragdismisslayout.ElasticDragDismissCallback;
 import com.commit451.elasticdragdismisslayout.ElasticDragDismissFrameLayout;
@@ -52,7 +53,8 @@ public class DetailActivity extends AppCompatActivity {
 
         draggableFrame.addListener(new ElasticDragDismissCallback() {
             @Override
-            public void onDrag(float elasticOffset, float elasticOffsetPixels, float rawOffset, float rawOffsetPixels) {}
+            public void onDrag(float elasticOffset, float elasticOffsetPixels, float rawOffset, float rawOffsetPixels) {
+            }
 
             @Override
             public void onDragDismissed() {

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/DetailRecyclerViewActivity.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/DetailRecyclerViewActivity.java
@@ -4,14 +4,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.commit451.elasticdragdismisslayout.ElasticDragDismissCallback;
 import com.commit451.elasticdragdismisslayout.ElasticDragDismissLinearLayout;

--- a/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/MainActivity.java
+++ b/app/src/main/java/com/commit451/elasticdragdismisslayout/sample/MainActivity.java
@@ -2,11 +2,12 @@ package com.commit451.elasticdragdismisslayout.sample;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -1,5 +1,4 @@
-<com.commit451.elasticdragdismisslayout.ElasticDragDismissFrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.commit451.elasticdragdismisslayout.ElasticDragDismissFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/draggable_frame"
     android:layout_width="match_parent"
@@ -16,13 +15,13 @@
         android:layout_height="match_parent"
         android:background="@android:color/white" />
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary" />
 
-    <android.support.v4.widget.NestedScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="?attr/actionBarSize">
@@ -43,6 +42,6 @@
 
         </LinearLayout>
 
-    </android.support.v4.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
 
 </com.commit451.elasticdragdismisslayout.ElasticDragDismissFrameLayout>

--- a/app/src/main/res/layout/activity_detail_recyclerview.xml
+++ b/app/src/main/res/layout/activity_detail_recyclerview.xml
@@ -1,5 +1,4 @@
-<com.commit451.elasticdragdismisslayout.ElasticDragDismissLinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.commit451.elasticdragdismisslayout.ElasticDragDismissLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/draggable_frame"
     android:layout_width="match_parent"
@@ -8,13 +7,13 @@
     app:dragDismissDistance="@dimen/drag_dismiss_distance"
     app:dragDismissScale="0.95">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="#993F51B5" />
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"/>
+        android:background="?attr/colorPrimary" />
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        />
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }

--- a/elasticdragdismisslayout/build.gradle
+++ b/elasticdragdismisslayout/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:support-v4:27.0.2'
+    api 'androidx.legacy:legacy-support-v4:1.0.0'
 }
 
 apply from: 'https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.0.0/gradle-android-javadocs.gradle'

--- a/elasticdragdismisslayout/build.gradle
+++ b/elasticdragdismisslayout/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14

--- a/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissDelegate.java
+++ b/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissDelegate.java
@@ -2,10 +2,11 @@ package com.commit451.elasticdragdismisslayout;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewPropertyAnimator;
+
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +119,7 @@ public class ElasticDragDismissDelegate {
         boolean draggingUp = enableBottomDrag && this.draggingUp;
         if (scroll == 0) return;
         if (draggingUp || scroll < 0)
-         totalDrag += scroll;
+            totalDrag += scroll;
 
         // track the direction & set the pivot point for scaling
         // don't double track i.e. if start dragging down and then reverse, keep tracking as

--- a/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissFrameLayout.java
+++ b/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissFrameLayout.java
@@ -19,10 +19,11 @@ package com.commit451.elasticdragdismisslayout;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.support.v4.view.NestedScrollingParent;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
+
+import androidx.core.view.NestedScrollingParent;
 
 /**
  * A {@link FrameLayout} which responds to nested scrolls to create drag-dismissable layouts.

--- a/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissLinearLayout.java
+++ b/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissLinearLayout.java
@@ -3,11 +3,12 @@ package com.commit451.elasticdragdismisslayout;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.support.annotation.NonNull;
-import android.support.v4.view.NestedScrollingParent;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.NestedScrollingParent;
 
 /**
  * Like {@link ElasticDragDismissFrameLayout} but its parent is a {@link android.widget.LinearLayout}

--- a/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissRelativeLayout.java
+++ b/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissRelativeLayout.java
@@ -3,11 +3,12 @@ package com.commit451.elasticdragdismisslayout;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.support.annotation.NonNull;
-import android.support.v4.view.NestedScrollingParent;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.RelativeLayout;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.NestedScrollingParent;
 
 /**
  * Like {@link ElasticDragDismissFrameLayout} but its parent is a {@link android.widget.RelativeLayout}

--- a/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/Util.java
+++ b/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/Util.java
@@ -2,9 +2,10 @@ package com.commit451.elasticdragdismisslayout;
 
 import android.content.res.TypedArray;
 import android.os.Build;
-import android.support.v4.widget.NestedScrollView;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
+
+import androidx.core.widget.NestedScrollView;
 
 class Util {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 11 19:27:59 CST 2017
+#Mon Jun 24 18:18:05 JST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Migrated this amazing library to AndroidX to make it unnecessary to specify jetifier in AndroidX project.

- Updated compileSdkVersion to 28
- Use AGP latest stable version: 3.4.1